### PR TITLE
Add #include <stdint.h> to fix compilation error

### DIFF
--- a/nfapi/src/nfapi_p4.c
+++ b/nfapi/src/nfapi_p4.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/nfapi/src/nfapi_p5.c
+++ b/nfapi/src/nfapi_p5.c
@@ -25,6 +25,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>

--- a/nfapi/src/nfapi_p7.c
+++ b/nfapi/src/nfapi_p7.c
@@ -27,6 +27,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
There are some compilation errors when compiling this project on 64-bit Ubuntu 17.10 with gcc-7 compiler.

Adding `#include <stdint.h>` can fix them.